### PR TITLE
Add BDD tests to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,21 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           file: ./coverage.xml
+
+      - name: Install Chrome for BDD tests
+        run: |
+          apt-get update
+          apt-get install -y chromium chromium-driver
+
+      - name: Start Flask service in background
+        env:
+          DATABASE_URI: "postgresql+psycopg://postgres:pgs3cr3t@postgres:5432/postgres"
+        run: |
+          gunicorn --bind 0.0.0.0:8080 --log-level=info wsgi:app &
+          sleep 5
+          curl http://localhost:8080/
+
+      - name: Run BDD tests
+        env:
+          BASE_URL: "http://localhost:8080"
+        run: behave


### PR DESCRIPTION
Changes:
- Install Chrome/Chromium for Selenium
- Start Flask service with gunicorn before BDD tests
- Run behave tests with BASE_URL environment variable
- Verify service is up with curl before running tests

All UI PRs now require passing BDD tests