### PR TITLE
refined PostgreSQL deployment with yaml to run in openshift

### DIFF
--- a/k8s/postgres/configmap.yaml
+++ b/k8s/postgres/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+  labels:
+    app: postgres
+data:
+  POSTGRES_DB: inventory
+  POSTGRES_USER: postgres

--- a/k8s/postgres/secret.yaml
+++ b/k8s/postgres/secret.yaml
@@ -5,6 +5,6 @@ metadata:
   labels:
     app: postgres
 type: Opaque
-stringData:
-  database_uri: postgresql+psycopg://postgres:pgs3cr3t@postgres:5432/inventory
-  password: pgs3cr3t
+data:
+  database_uri: cG9zdGdyZXNxbCtwc3ljb3BnOi8vcG9zdGdyZXM6cGdzM2NyM3RAcG9zdGdyZXM6NTQzMi9pbnZlbnRvcnk=
+  password: cGdzM2NyM3Q=

--- a/k8s/postgres/statefulset.yaml
+++ b/k8s/postgres/statefulset.yaml
@@ -23,7 +23,16 @@ spec:
           protocol: TCP
         env:
         - name: POSTGRES_DB
-          value: inventory
+          valueFrom:
+            configMapKeyRef:
+              name: postgres-config
+              key: POSTGRES_DB
+
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              name: postgres-config
+              key: POSTGRES_USER
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
- The project already has a basic Kubernetes setup, but it has been reorganized to follow the structure by the recent lab.
- Verified that the PostgreSQL component deploys correctly in an OpenShift environment.
- Re-ran local Kubernetes tests using `make cluster`, `make build`, `make push`, and `make deploy`.

Note: The actual PostgreSQL deployment on the team OpenShift cluster will require running the following command after the shared cluster is created:
`oc apply -f k8s/postgresql/`